### PR TITLE
Make text copy to system clipboard.

### DIFF
--- a/content.js
+++ b/content.js
@@ -2,48 +2,35 @@
 var addClipboard = {
 	"id": "Parent",
 	"title": "Add to Clipboard",
-	"contexts": ["selection"] //
-};
-//information about paste clipboard button
-var pasteClipboard = {
-	"id": "child",
-	"title": "Paste Clipboard",
-	"contexts": ["page"],
-	visible: false
+	"contexts": ["selection"] 
 };
 
 //String used to append the selected text to console
 var fullString =  "";
 
-//initialize the two buttons in the context menu
-
+//initialize one button in the context menu
 chrome.contextMenus.create(addClipboard);
 
-chrome.contextMenus.create(pasteClipboard);
+function copyTextToClipboard(text){
+	var copyFrom = document.createElement("textarea");
+	copyFrom.textContent = text;
+	document.body.appendChild(copyFrom);
+	copyFrom.select();
+
+	try {
+		document.execCommand('copy');
+		copyFrom.blur();
+	} catch {
+		pass;
+	} finally {
+		document.body.removeChild(copyFrom);
+	}
+}
 
 //Function waits for user to click button and updates the string as well as makes the paste clipboard button visible
 chrome.contextMenus.onClicked.addListener(function(copiedData){
-	if(copiedData.menuItemId == "Parent" && copiedData.selectionText){
-		fullString = [fullString,copiedData.selectionText].join(' ');
-		chrome.contextMenus.update("child", {visible : true});
-		//TO DO: 
-		//access windows clipboard and append string to clipboard
-		console.log(fullString);
-	}
-
-
-});
-
-//Function that sends message to console once the paste button is clicked
-//code not complete
-chrome.contextMenus.onClicked.addListener(function(pasteData){
-	if(pasteData.menuItemId =="child" && fullString.length > 0){
-		//TO DO: 
-		//probably won't be necessary if we gain access to windows clipboard
-		//if we can't get access then we can communicate with content script 
-		//to paste message on screen
-		console.log("button working");
+	if (copiedData.selectionText){
+		fullString += copiedData.selectionText;
+		copyTextToClipboard(fullString);
 	}
 });
-
-

--- a/manifest.json
+++ b/manifest.json
@@ -1,22 +1,23 @@
-  {
-    "name": "FastPaste",
-    "version": "0.1.0",
-    "description": "Tool to allow users to use Copy & Paste more efficiently!",
-    "manifest_version": 2,
-    "permissions": ["contextMenus"],
-    "icons": {
-          "48": "clipboard.png"
-    },
+{
+  "name": "FastPaste",
+  "version": "0.1.0",
+  "description": "Tool to allow users to use Copy & Paste more efficiently!",
+  "manifest_version": 2,
+  "permissions": [
+    "contextMenus",
+    "storage",
+    "clipboardRead",
+    "clipboardWrite"
+  ],
+  "icons": {
+    "48": "clipboard.png"
+  },
   "background": {
     "persistent": false,
     "scripts": ["content.js"]
   },
-    "browser_action":
-    {
-    	"default_icon": "picture.png",
-    	"default_title": "Click here for more options"
-
-
-    }
-
+  "browser_action": {
+    "default_icon": "picture.png",
+    "default_title": "Click here for more options"
   }
+}


### PR DESCRIPTION
Changes:

- Reindent code. 
- Make text copy to system clipboard. 
- Remove pasteClipboard since we can just use the normal Ctrl-V.

Sources:
- https://stackoverflow.com/questions/3436102/copy-to-clipboard-in-chrome-extension/18455088#18455088
