### PR TITLE
Remove copy to clipboard selection since we can just Ctrl-V now.

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,22 +1,14 @@
-//information about add to clipboard button
-var addClipboard = {
-	"id": "Parent",
-	"title": "Add to Clipboard",
-	"contexts": ["selection"] 
-};
-
 var clearClipboard = {
 	"id": "child",
 	"title": "Clear the Clipboard",
 	"contexts": ["page"],
-	visible: false
+	visible: true
 };
 
 //String used to append the selected text to console
 var fullString =  "";
 
 //initialize two buttons in the context menu
-chrome.contextMenus.create(addClipboard);
 chrome.contextMenus.create(clearClipboard);
 
 
@@ -36,25 +28,17 @@ function copyTextToClipboard(text){
 	}
 };
 
-//Function waits for user to click button and updates the string as well as makes the clear clipboard button visible
-chrome.contextMenus.onClicked.addListener(function(copiedData){
-	//checks if user interacted with Parent button and appends to clipboard
-	if(copiedData.menuItemId === "Parent" && copiedData.selectionText){
-		fullString = [fullString,copiedData.selectionText].join(' ');
+chrome.extension.onMessage.addListener(
+	(message, sender, sendResponse) => {
+		fullString = [fullString, message.text].join(" ");
 		copyTextToClipboard(fullString);
-		chrome.contextMenus.update("child", {visible : true});
 	}
-});
-
-
-
-
+)
 //function works regardless if user interacts with it or not
 chrome.contextMenus.onClicked.addListener(function(clearData){
 	//clears full string but should clear the windows clipboard as well
 	if(clearData.menuItemId === "child" && fullString.length > 0 ){
 		fullString = "";
-		copyTextToClipboard(' ');
-		chrome.contextMenus.update("child", {visible : false});
+		copyTextToClipboard(" ");
 	}
 });

--- a/copy.js
+++ b/copy.js
@@ -1,4 +1,5 @@
 document.addEventListener('copy', (event) => {
 	const selection = document.getSelection();
     chrome.runtime.sendMessage({text: selection.toString()});
+    event.preventDefault()
 })

--- a/copy.js
+++ b/copy.js
@@ -1,0 +1,4 @@
+document.addEventListener('copy', (event) => {
+	const selection = document.getSelection();
+    chrome.runtime.sendMessage({text: selection.toString()});
+})

--- a/manifest.json
+++ b/manifest.json
@@ -19,5 +19,11 @@
   "browser_action": {
     "default_icon": "picture.png",
     "default_title": "Click here for more options"
-  }
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["copy.js"]
+    }
+  ]
 }


### PR DESCRIPTION
Sources:
- https://stackoverflow.com/questions/48922973/how-to-catch-a-copy-event-on-a-web-page-with-chrome-extension-running-in-the-bac